### PR TITLE
Add shell-session to tested scripts

### DIFF
--- a/profiles/consul/controls/validate.rb
+++ b/profiles/consul/controls/validate.rb
@@ -57,7 +57,7 @@ markdown_files.each do |file|
           describe json_syntax(value: section.value) do
               it { should be_valid }
           end
-        when 'shell'
+        when /shell|shell-session/ 
           describe shell_syntax(value: section.value, replacements: input("replacements") ) do
               it { should be_valid }
           end

--- a/profiles/github/controls/action.rb
+++ b/profiles/github/controls/action.rb
@@ -80,7 +80,7 @@ markdown_files.each do |file|
           describe json_syntax(value: section.value) do
               it { should be_valid }
           end
-        when 'shell'
+        when /shell|shell-session/
           describe shell_syntax(value: section.value, replacements: input("replacements") ) do
               it { should be_valid }
           end

--- a/profiles/nomad/controls/validate.rb
+++ b/profiles/nomad/controls/validate.rb
@@ -57,7 +57,7 @@ markdown_files.each do |file|
           describe json_syntax(value: section.value) do
               it { should be_valid }
           end
-        when 'shell'
+        when /shell|shell-session/ 
           describe shell_syntax(value: section.value, replacements: input("replacements") ) do
               it { should be_valid }
           end

--- a/profiles/terraform/controls/validate.rb
+++ b/profiles/terraform/controls/validate.rb
@@ -57,7 +57,7 @@ markdown_files.each do |file|
           describe json_syntax(value: section.value) do
               it { should be_valid }
           end
-        when 'shell'
+        when /shell|shell-session/ 
           describe shell_syntax(value: section.value, replacements: input("replacements") ) do
               it { should be_valid }
           end

--- a/profiles/vault/controls/validate.rb
+++ b/profiles/vault/controls/validate.rb
@@ -57,7 +57,7 @@ markdown_files.each do |file|
           describe json_syntax(value: section.value) do
               it { should be_valid }
           end
-        when 'shell'
+        when /shell|shell-session/ 
           describe shell_syntax(value: section.value, replacements: input("replacements") ) do
               it { should be_valid }
           end


### PR DESCRIPTION
Prior to this commit the codebase/docs did not use shell-session as we
were using a highlight.js , we switched to a new syntax highlighter and
it supports a distiction between shell scripts and terminal sessions.
This change updates the tests use either.