### PR TITLE
Don't catch powershell, only ^shell

### DIFF
--- a/profiles/github/controls/action.rb
+++ b/profiles/github/controls/action.rb
@@ -80,7 +80,7 @@ markdown_files.each do |file|
           describe json_syntax(value: section.value) do
               it { should be_valid }
           end
-        when /shell|shell-session/
+        when /^shell|shell-session/
           describe shell_syntax(value: section.value, replacements: input("replacements") ) do
               it { should be_valid }
           end


### PR DESCRIPTION
Prior to this PR powershell was caught in the regex and then parsed and checked with shell