### PR TITLE
feat: adds default_branch input option to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@
 # The input system will in the future allow more then learn
 # to be targeted by the profiles in this directory.
 name: 'Check markdown codeblocks'
-author: "Zack Smith"
+author: 'Zack Smith'
 description: 'Run inspec against markdown'
 inputs:
   profile:
@@ -19,16 +19,21 @@ inputs:
   file_pattern:
     description: 'The file glob e.g. pages/**/*.mdx'
     required: true
+  default_branch:
+    description: 'The default branch in the target repository'
+    default: 'master'
+    required: false
 outputs:
   inspec-output:
     description: 'The output of inspec'
 runs:
   using: 'docker'
-  image: 'docker://hashieducation/inspec' 
+  image: 'docker://hashieducation/inspec'
   env:
     MARKDOWN: ${{ inputs.markdown }}
     GITHUB_TOKEN: ${{ inputs.github_token }}
     FILE_PATTERN: ${{ inputs.file_pattern }}
+    DEFAULT_BRANCH: ${{ inputs.default_branch }}
   args:
     - 'exec'
     - /profiles/${{ inputs.profile }}
@@ -42,5 +47,5 @@ runs:
     - '--input-file'
     - '/input.yml'
 branding:
-  color: "black"
-  icon: "dollar-sign"
+  color: 'black'
+  icon: 'dollar-sign'

--- a/profiles/github/controls/action.rb
+++ b/profiles/github/controls/action.rb
@@ -24,7 +24,7 @@ begin
                              "heads/#{branch}")
 
  master_branch  = github.ref(repository,
-                             'heads/master')
+                             ENV['DEFAULT_BRANCH'])
  comparison     = github.compare(repository,
                                  master_branch.object.sha,
                                  feature_branch.object.sha)


### PR DESCRIPTION
This PR adds a `default_branch` input option to the GitHub action, which defaults to `master`. This will allow us to configure the action on a new repo that uses `main` as the default. 

If the implementation / idea looks good, I can update any documentation as needed. 